### PR TITLE
Zero-pad W if it is odd

### DIFF
--- a/code/stimulus_generation/@AbstractBinnedStimulusGenerationMethod/AbstractBinnedStimulusGenerationMethod.m
+++ b/code/stimulus_generation/@AbstractBinnedStimulusGenerationMethod/AbstractBinnedStimulusGenerationMethod.m
@@ -168,6 +168,11 @@ methods
             Fs = self.get_fs();
         end
 
+        if mod(length(W), 2) ~= 0
+            warning('W is not of even length, will zero-pad.')
+            W(end+1, :) = 0;
+        end
+
         nfft = length(W);
         dur = self.duration;
 


### PR DESCRIPTION
`ABSG.bin_signal()` now will throw a warning and zero-pad so that `W` is even.