### PR TITLE
Resynth volume

### DIFF
--- a/code/experiment/Protocol.m
+++ b/code/experiment/Protocol.m
@@ -131,7 +131,7 @@ function Protocol(options)
     fid_responses = fopen(filename_responses, 'w');
 
     %% Adjust target audio volume
-    if ~isempty(target_sound)
+    if ~isempty(target_sound) && ~contains(config.target_audio_filepath,'resynth_wavs')
         if is_two_afc
             scale_factor = adjust_volume(target_sound, target_fs, stimuli_matrix_1(:,1), Fs);
         else
@@ -160,7 +160,11 @@ function Protocol(options)
 
         % Present Target (if A-X protocol)
         if ~isempty(target_sound)
-            sound(target_sound*scale_factor, target_fs)
+            if ~contains(config.target_audio_filepath,'resynth_wavs')
+                sound(target_sound*scale_factor, target_fs)
+            else
+                soundsc(target_sound,target_fs)
+            end
             pause(length(target_sound) / target_fs + 0.3) % ACL added (5MAY2022) to add 300ms pause between target and stimulus
         end
 


### PR DESCRIPTION
Resynthesized wav files were too quiet to be fixed by adjust_volume, so changed to soundsc if resynth.