### PR TITLE
Nb datacollection

### DIFF
--- a/code/experiment/Protocol.m
+++ b/code/experiment/Protocol.m
@@ -60,7 +60,6 @@ function Protocol(options)
     if isfield(config, 'stimuli_type') && ~isempty(config.stimuli_type)
         % There is a weird feature/bug where putting `stimuli_type: white`
         % in the config file returns a 256x3 matrix of ones.
-%         if ~isa(config.stimuli_type, 'string')
         if strcmpi(config.stimuli_type,'white')
             config.stimuli_type = "UniformNoiseNoBins";
         end

--- a/code/utils/config2table.m
+++ b/code/utils/config2table.m
@@ -40,6 +40,7 @@ function data_table = config2table(curr_dir, variables_to_remove)
     config = parse_config(pathlib.join(config_file.folder, config_file.name));
     
     data_table = cellstr4tables(struct2table(config));
+    data_table.config_hash = get_hash(config);
     data_table.ID = 1;
     
     % Create and outer join each new data table, keeping column names the same
@@ -49,6 +50,7 @@ function data_table = config2table(curr_dir, variables_to_remove)
             config = parse_config(pathlib.join(config_file.folder, config_file.name));
     
             new_data_table = cellstr4tables(struct2table(config));
+            new_data_table.config_hash = get_hash(config);
             new_data_table.ID = ii;
             data_table = outerjoin(data_table, new_data_table, 'MergeKeys', true);
         end
@@ -66,6 +68,7 @@ function data_table = config2table(curr_dir, variables_to_remove)
     end
         
     data_table = removevars(data_table,remove_fields);
+    data_table = sortrows(data_table, 'ID');
 
 end % function
 

--- a/code/utils/waittext.m
+++ b/code/utils/waittext.m
@@ -135,7 +135,7 @@ nargoutchk(0,1);
 % Check if spmd mode
 hasSPMD = (exist('spmd','builtin') == 5);
 if nargin > 2
-    isspmd = strcmpi(varargin{end-1},'spmd') && hasSPMD && numlabs > 1;
+    isspmd = strcmpi(varargin{end-1},'spmd') && hasSPMD && spmdSize > 1;
     if isspmd
         labtarget = varargin{end};
         if any(strcmpi(labtarget,{'all','true','on','yes'}))
@@ -147,7 +147,7 @@ if nargin > 2
             end
             if ~isnumeric(labtarget) || ~isreal(labtarget) ...
                     || ~isfinite(labtarget) || labtarget < 1 ...
-                    || labtarget > numlabs || labtarget ~= floor(labtarget)
+                    || labtarget > spmdSize || labtarget ~= floor(labtarget)
                 error('waittext:waittext:NonFiniteRealLabTarget',...
                      ['LABTARGET must be a finite real integer between one '...
                       'and NUMLABS.']);
@@ -186,12 +186,12 @@ if ischar(varargin{1})
     % Global concatenation for spmd mode
     if isspmd
         if isAllLabs
-            msg = gcat([msg ', '],2);
+            msg = spmdCat([msg ', '],2);
             if ~isempty(msg)
                 msg = msg(1:end-2);
             end
         else
-            msg = gop(@(x,y){x;y},msg,1);
+            msg = spmdReduce(@(x,y){x;y},msg,1);
             if ~isempty(msg) && iscell(msg)
                 msg = msg{labtarget,:};
             end
@@ -216,9 +216,9 @@ else
     % Global summation for spmd mode
     if isspmd
         if isAllLabs
-            x = gop(@plus,x/numlabs,1);
+            x = spmdReduce(@plus,x/spmdSize,1);
         else
-            x = gcat(x,1,1);
+            x = spmdCat(x,1,1);
             if ~isempty(x)
                 x = x(labtarget);
             end
@@ -230,7 +230,7 @@ end
 sp = ' ';
 spmdsp = double(isspmd)*2;
 
-if hasSPMD && labindex == 1 || ~hasSPMD && ~isspmd
+if hasSPMD && spmdIndex == 1 || ~hasSPMD && ~isspmd
     % Print message with carriage return in case of error or warning during wait
     if any(strcmp(msgtype,{'init','initial','initialize','first'}))
         if x ~= 0


### PR DESCRIPTION
* Move sortrows() from pilot_reconstructions.m to config2table.m
* Add config hash to pilot_reconstructions.m output table
* Use config hash to get exact number of trials completed into T.total_trials instead of reading from config (helps double check all data is there, good for early reconstructions, too).
* Accepted MATLAB's suggestions for analogous, new functions within waittext.m.
* Remove extraneous comments from Protocol.m and pilot_reconstructions.m