### PR TITLE
Change empty bins from 0dB to -100dB

### DIFF
--- a/code/stimulus_generation/@AbstractBinnedStimulusGenerationMethod/AbstractBinnedStimulusGenerationMethod.m
+++ b/code/stimulus_generation/@AbstractBinnedStimulusGenerationMethod/AbstractBinnedStimulusGenerationMethod.m
@@ -131,7 +131,7 @@ methods
         % spect2binnedrepr
 
         B = self.get_freq_bins();
-        T = zeros(length(B), size(binned_repr, 2));
+        T = -100 * ones(length(B), size(binned_repr, 2));
         for bin_num = 1:self.n_bins
             T(B == bin_num, :) = repmat(binned_repr(bin_num, :), sum(B == bin_num), 1);
         end


### PR DESCRIPTION
When converting binned --> spectrum, empty bins (in our case typically 0-100hZ and >13kHz) were set to 0dB, which is the max dB we've been assigning. This changes the unused bins to -100dB. Everywhere I can find where `binnedrepr2spect` is called, this isn't an issue, but I do think this is a correct change. 